### PR TITLE
Force Node.js 24 for setup-php to fix deprecation warning

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -266,6 +266,8 @@ runs:
 
         -   name: Setup PHP
             uses: shivammathur/setup-php@v2
+            env:
+                FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
             with:
                 php-version: "${{ inputs.php_version }}"
                 extensions: "${{ inputs.php_extensions }}"


### PR DESCRIPTION
GitHub is deprecating Node.js 20 actions starting June 2, 2026. `shivammathur/setup-php@v2` still runs on Node.js 20 and there is no v3 available yet.

This adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env to the setup-php step to opt into Node.js 24 early and suppress the deprecation warning in all downstream workflows.